### PR TITLE
feat: auto-refresh skills standings daily with season auto-detection

### DIFF
--- a/docs/superpowers/plans/2026-04-13-auto-skills-refresh.md
+++ b/docs/superpowers/plans/2026-04-13-auto-skills-refresh.md
@@ -1,0 +1,757 @@
+# Auto Skills Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically refresh world skills standings daily via RobotEvents internal API, replacing manual CSV uploads, with a 3-tier cached season ID auto-detection system.
+
+**Architecture:** A `node-cron` job in the Express server fetches 4 skills datasets daily and upserts into `skills_standings`. A shared `getCurrentSeasonId()` utility resolves season IDs via memory cache → DB → API → env var fallback, replacing all hardcoded `CURRENT_SEASON_ID` references. Admin endpoints expose refresh status and manual trigger.
+
+**Tech Stack:** Node.js, Express, PostgreSQL, node-cron, node-fetch
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/api/services/seasonResolver.js` | Create | 3-tier season ID resolution (memory → DB → API → env) |
+| `src/api/services/skillsRefresh.js` | Create | Fetch skills data from RobotEvents, upsert into DB, retry logic |
+| `src/api/server.js` | Modify | Add `season_config` table, cron setup, admin endpoints, replace hardcoded season IDs |
+| `package.json` | Modify | Add `node-cron` dependency |
+
+---
+
+### Task 1: Add `node-cron` Dependency
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install node-cron**
+
+```bash
+npm install node-cron
+```
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+node -e "import('node-cron').then(c => console.log('node-cron loaded, validate:', c.default.validate('0 3 * * *')))"
+```
+
+Expected: `node-cron loaded, validate: true`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add node-cron dependency for scheduled skills refresh"
+```
+
+---
+
+### Task 2: Create Season Resolver Service
+
+**Files:**
+- Create: `src/api/services/seasonResolver.js`
+
+- [ ] **Step 1: Create the season resolver module**
+
+This module exports `getCurrentSeasonId(pool, programId)` with the 3-tier cache (memory → DB → API → env var → critical error), and `refreshSeasonId(pool, programId)` which bypasses the memory cache (used by the daily cron to check for season changes).
+
+```js
+// src/api/services/seasonResolver.js
+import fetch from 'node-fetch';
+
+// In-memory cache: Map<programKey, { seasonId, seasonName }>
+// programKey is 'VRC' or 'VEXIQ'
+const seasonCache = new Map();
+
+// Map program IDs to keys and env var names
+const PROGRAM_CONFIG = {
+  1:  { key: 'VRC',   envVar: 'CURRENT_SEASON_ID' },
+  41: { key: 'VEXIQ', envVar: 'VEXIQ_SEASON_ID' },
+};
+
+/**
+ * Get the current season ID for a program.
+ * Resolution: memory cache → DB → API → env var → critical error.
+ * 
+ * @param {import('pg').Pool} pool - Database pool
+ * @param {number} programId - RobotEvents program ID (1=VRC, 41=VEXIQ)
+ * @returns {Promise<number|null>} Season ID or null if all tiers fail
+ */
+export async function getCurrentSeasonId(pool, programId) {
+  const config = PROGRAM_CONFIG[programId];
+  if (!config) {
+    console.error(`[season-resolver] Unknown program ID: ${programId}`);
+    return null;
+  }
+
+  // Tier 1: Memory cache
+  if (seasonCache.has(config.key)) {
+    return seasonCache.get(config.key).seasonId;
+  }
+
+  // Tier 2: Database
+  try {
+    const result = await pool.query(
+      'SELECT season_id, season_name FROM season_config WHERE program = $1',
+      [config.key]
+    );
+    if (result.rows.length > 0) {
+      const { season_id, season_name } = result.rows[0];
+      seasonCache.set(config.key, { seasonId: season_id, seasonName: season_name });
+      console.log(`[season-resolver] ${config.key} season loaded from DB: ${season_id} (${season_name})`);
+      return season_id;
+    }
+  } catch (err) {
+    console.error(`[season-resolver] DB read failed for ${config.key}:`, err.message);
+  }
+
+  // Tier 3: API
+  const apiResult = await fetchSeasonFromApi(programId);
+  if (apiResult) {
+    await saveSeasonToDb(pool, config.key, apiResult.seasonId, apiResult.seasonName);
+    seasonCache.set(config.key, apiResult);
+    console.log(`[season-resolver] ${config.key} season resolved from API: ${apiResult.seasonId} (${apiResult.seasonName})`);
+    return apiResult.seasonId;
+  }
+
+  // Tier 4: Environment variable fallback
+  const envValue = process.env[config.envVar];
+  if (envValue) {
+    const seasonId = parseInt(envValue);
+    seasonCache.set(config.key, { seasonId, seasonName: 'from env var' });
+    console.warn(`[season-resolver] ${config.key} season using env var fallback: ${seasonId}`);
+    return seasonId;
+  }
+
+  // Tier 5: Critical error
+  console.error(`[CRITICAL] Could not determine ${config.key} season ID. No API, DB, or env var available.`);
+  return null;
+}
+
+/**
+ * Refresh the season ID by calling the API directly (bypasses memory cache).
+ * Used by the daily cron to detect season changes.
+ * Updates DB and memory cache if the season has changed.
+ * 
+ * @param {import('pg').Pool} pool - Database pool
+ * @param {number} programId - RobotEvents program ID (1=VRC, 41=VEXIQ)
+ * @returns {Promise<number|null>} Season ID or null on failure
+ */
+export async function refreshSeasonId(pool, programId) {
+  const config = PROGRAM_CONFIG[programId];
+  if (!config) return null;
+
+  const apiResult = await fetchSeasonFromApi(programId);
+  if (apiResult) {
+    const cached = seasonCache.get(config.key);
+    if (!cached || cached.seasonId !== apiResult.seasonId) {
+      console.log(`[season-resolver] ${config.key} season changed: ${cached?.seasonId || 'none'} → ${apiResult.seasonId} (${apiResult.seasonName})`);
+      await saveSeasonToDb(pool, config.key, apiResult.seasonId, apiResult.seasonName);
+    }
+    seasonCache.set(config.key, apiResult);
+    return apiResult.seasonId;
+  }
+
+  // API failed — fall back to getCurrentSeasonId which tries DB → env
+  console.warn(`[season-resolver] API refresh failed for ${config.key}, falling back to cached value`);
+  return getCurrentSeasonId(pool, programId);
+}
+
+/**
+ * Fetch the current season from RobotEvents v2 API.
+ * Picks the most recent season whose start date is in the past.
+ */
+async function fetchSeasonFromApi(programId) {
+  const apiToken = process.env.ROBOTEVENTS_API_TOKEN;
+  if (!apiToken) {
+    console.warn('[season-resolver] No ROBOTEVENTS_API_TOKEN configured, skipping API lookup');
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.robotevents.com/api/v2/seasons?program[]=${programId}&per_page=5`,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiToken}`,
+          'Accept': 'application/json'
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error(`[season-resolver] API returned ${response.status} for program ${programId}`);
+      return null;
+    }
+
+    const data = await response.json();
+    const now = new Date();
+
+    for (const season of data.data) {
+      const start = new Date(season.start);
+      if (now >= start) {
+        return { seasonId: season.id, seasonName: season.name };
+      }
+    }
+
+    console.warn(`[season-resolver] No started season found for program ${programId}`);
+    return null;
+  } catch (err) {
+    console.error(`[season-resolver] API fetch failed for program ${programId}:`, err.message);
+    return null;
+  }
+}
+
+/**
+ * Save a season ID to the database (upsert).
+ */
+async function saveSeasonToDb(pool, programKey, seasonId, seasonName) {
+  try {
+    await pool.query(`
+      INSERT INTO season_config (program, season_id, season_name, updated_at)
+      VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+      ON CONFLICT (program) DO UPDATE SET
+        season_id = EXCLUDED.season_id,
+        season_name = EXCLUDED.season_name,
+        updated_at = CURRENT_TIMESTAMP
+    `, [programKey, seasonId, seasonName]);
+  } catch (err) {
+    console.error(`[season-resolver] Failed to save season to DB:`, err.message);
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/api/services/seasonResolver.js
+git commit -m "feat: add season resolver with 3-tier cache (memory/DB/API)"
+```
+
+---
+
+### Task 3: Create Skills Refresh Service
+
+**Files:**
+- Create: `src/api/services/skillsRefresh.js`
+
+- [ ] **Step 1: Create the skills refresh module**
+
+This module exports `runSkillsRefresh(pool)` which fetches all 4 datasets and upserts them, and exposes a status object.
+
+```js
+// src/api/services/skillsRefresh.js
+import fetch from 'node-fetch';
+import { refreshSeasonId } from './seasonResolver.js';
+
+// In-memory status for admin visibility
+export const refreshStatus = {
+  lastRefreshedAt: null,
+  isRunning: false,
+  lastResult: null,
+};
+
+// Dataset configurations
+const DATASETS = [
+  { matchType: 'VRC',   programId: 1,  gradeLevel: 'High School',       label: 'VRC High School' },
+  { matchType: 'VRC',   programId: 1,  gradeLevel: 'Middle School',     label: 'VRC Middle School' },
+  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Middle School',     label: 'VEXIQ Middle School' },
+  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Elementary School', label: 'VEXIQ Elementary School' },
+];
+
+/**
+ * Run the full skills refresh cycle.
+ * Resolves season IDs, fetches 4 datasets, upserts into skills_standings.
+ * 
+ * @param {import('pg').Pool} pool - Database pool
+ */
+export async function runSkillsRefresh(pool) {
+  if (refreshStatus.isRunning) {
+    console.log('[skills-refresh] Already running, skipping');
+    return;
+  }
+
+  refreshStatus.isRunning = true;
+  const startTime = Date.now();
+  const results = {};
+  let totalRecords = 0;
+  let failures = 0;
+  let retries = 0;
+
+  console.log(`[skills-refresh] Starting scheduled refresh at ${new Date().toISOString()}`);
+
+  // Step 1: Resolve season IDs (calls API directly to detect changes)
+  const vrcSeasonId = await refreshSeasonId(pool, 1);
+  const vexiqSeasonId = await refreshSeasonId(pool, 41);
+
+  console.log(`[skills-refresh] Season IDs resolved — VRC: ${vrcSeasonId}, VEXIQ: ${vexiqSeasonId}`);
+
+  // Step 2: Process each dataset
+  for (const dataset of DATASETS) {
+    const seasonId = dataset.programId === 1 ? vrcSeasonId : vexiqSeasonId;
+
+    if (!seasonId) {
+      console.error(`[skills-refresh] ${dataset.label}: SKIPPED — no season ID available`);
+      results[dataset.label] = { records: 0, status: 'skipped' };
+      failures++;
+      continue;
+    }
+
+    const result = await fetchAndUpsertDataset(pool, seasonId, dataset);
+    results[dataset.label] = result;
+
+    if (result.status === 'success') {
+      totalRecords += result.records;
+      if (result.retried) retries++;
+    } else {
+      failures++;
+    }
+
+    // Wait 1.5s between datasets to avoid hammering the server
+    if (DATASETS.indexOf(dataset) < DATASETS.length - 1) {
+      await sleep(1500);
+    }
+  }
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  refreshStatus.lastRefreshedAt = new Date().toISOString();
+  refreshStatus.isRunning = false;
+  refreshStatus.lastResult = {
+    duration: `${duration}s`,
+    datasets: results,
+    totalRecords,
+    failures,
+    retries,
+  };
+
+  console.log(`[skills-refresh] Completed in ${duration}s — ${totalRecords} total records, ${retries} retries, ${failures} failures`);
+}
+
+/**
+ * Fetch a single dataset from RobotEvents and upsert into skills_standings.
+ * Retries once on failure.
+ */
+async function fetchAndUpsertDataset(pool, seasonId, dataset) {
+  let data = null;
+  let retried = false;
+
+  // Attempt 1
+  data = await fetchSkillsData(seasonId, dataset.gradeLevel);
+
+  // Retry once on failure
+  if (!data) {
+    console.warn(`[skills-refresh] ${dataset.label}: FAILED (retrying in 5s...)`);
+    retried = true;
+    await sleep(5000);
+    data = await fetchSkillsData(seasonId, dataset.gradeLevel);
+  }
+
+  if (!data) {
+    console.error(`[skills-refresh] ${dataset.label}: FAILED after retry`);
+    return { records: 0, status: 'failed', retried };
+  }
+
+  // Upsert into database
+  try {
+    await pool.query('BEGIN');
+
+    for (const record of data) {
+      await pool.query(`
+        INSERT INTO skills_standings (
+          teamNumber, teamName, organization, eventRegion, countryRegion,
+          rank, score, autonomousSkills, driverSkills,
+          highestAutonomousSkills, highestDriverSkills, matchType
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ON CONFLICT (teamNumber, matchType) DO UPDATE SET
+          teamName = EXCLUDED.teamName,
+          organization = EXCLUDED.organization,
+          eventRegion = EXCLUDED.eventRegion,
+          countryRegion = EXCLUDED.countryRegion,
+          rank = EXCLUDED.rank,
+          score = EXCLUDED.score,
+          autonomousSkills = EXCLUDED.autonomousSkills,
+          driverSkills = EXCLUDED.driverSkills,
+          highestAutonomousSkills = EXCLUDED.highestAutonomousSkills,
+          highestDriverSkills = EXCLUDED.highestDriverSkills,
+          lastUpdated = CURRENT_TIMESTAMP
+      `, [
+        record.team.team,
+        record.team.teamName,
+        record.team.organization,
+        record.team.eventRegion || '',
+        record.team.country || '',
+        record.rank,
+        record.scores.score,
+        record.scores.programming,
+        record.scores.driver,
+        record.scores.maxProgramming,
+        record.scores.maxDriver,
+        dataset.matchType,
+      ]);
+    }
+
+    await pool.query('COMMIT');
+    console.log(`[skills-refresh] ${dataset.label}: ${data.length} records updated`);
+    return { records: data.length, status: 'success', retried };
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    console.error(`[skills-refresh] ${dataset.label}: DB error — ${err.message}`);
+    return { records: 0, status: 'failed', retried };
+  }
+}
+
+/**
+ * Fetch skills standings from the RobotEvents internal API.
+ * This is an undocumented API that does not require authentication.
+ * 
+ * @returns {Array|null} Array of team records or null on failure
+ */
+async function fetchSkillsData(seasonId, gradeLevel) {
+  try {
+    const url = `https://www.robotevents.com/api/seasons/${seasonId}/skills?post_season=0&grade_level=${encodeURIComponent(gradeLevel)}`;
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      }
+    });
+
+    if (!response.ok) {
+      console.error(`[skills-refresh] API returned ${response.status} for season ${seasonId}, grade ${gradeLevel}`);
+      return null;
+    }
+
+    const data = await response.json();
+
+    if (!Array.isArray(data)) {
+      console.error(`[skills-refresh] Unexpected response format for season ${seasonId}, grade ${gradeLevel}`);
+      return null;
+    }
+
+    return data;
+  } catch (err) {
+    console.error(`[skills-refresh] Fetch error for season ${seasonId}, grade ${gradeLevel}:`, err.message);
+    return null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/api/services/skillsRefresh.js
+git commit -m "feat: add skills refresh service with retry logic and admin status"
+```
+
+---
+
+### Task 4: Add `season_config` Table to Database Initialization
+
+**Files:**
+- Modify: `src/api/server.js:254-350` (inside `initializeDatabase()`)
+
+- [ ] **Step 1: Add the season_config table creation**
+
+In `src/api/server.js`, find the `initializeDatabase()` function. After the last `CREATE TABLE IF NOT EXISTS` block (the `tracked_teams` table around line 330), add:
+
+```js
+    // Create season_config table for caching auto-detected season IDs
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS season_config (
+        program TEXT PRIMARY KEY,
+        season_id INTEGER NOT NULL,
+        season_name TEXT,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/api/server.js
+git commit -m "feat: add season_config table for caching auto-detected season IDs"
+```
+
+---
+
+### Task 5: Replace Hardcoded Season IDs with Season Resolver
+
+**Files:**
+- Modify: `src/api/server.js:1-17` (imports)
+- Modify: `src/api/server.js:552` (analysis worker start)
+- Modify: `src/api/server.js:1226` (performance endpoint)
+- Modify: `src/api/server.js:1589` (team events endpoint)
+
+- [ ] **Step 1: Add import for seasonResolver**
+
+At the top of `src/api/server.js`, after the existing imports (around line 17), add:
+
+```js
+import { getCurrentSeasonId } from './services/seasonResolver.js';
+```
+
+- [ ] **Step 2: Update analysis worker start (line 552)**
+
+Change:
+
+```js
+  analysisWorker.start(pool, process.env.ROBOTEVENTS_API_TOKEN, process.env.CURRENT_SEASON_ID || 197, !!force);
+```
+
+To:
+
+```js
+  const seasonId = await getCurrentSeasonId(pool, 1); // VRC
+  analysisWorker.start(pool, process.env.ROBOTEVENTS_API_TOKEN, seasonId || 197, !!force);
+```
+
+Also make the route handler `async` if it isn't already. Change:
+
+```js
+app.post('/api/admin/analysis/start', authenticateToken, requireRole('admin'), (req, res) => {
+```
+
+To:
+
+```js
+app.post('/api/admin/analysis/start', authenticateToken, requireRole('admin'), async (req, res) => {
+```
+
+- [ ] **Step 3: Update performance endpoint (line 1226)**
+
+Change:
+
+```js
+    const seasonId = req.query.season || process.env.CURRENT_SEASON_ID || 197; // Default to current VRC season
+```
+
+To:
+
+```js
+    const seasonId = req.query.season || await getCurrentSeasonId(pool, 1) || 197;
+```
+
+- [ ] **Step 4: Update team events endpoint (line 1589)**
+
+Change:
+
+```js
+    const seasonId = season || process.env.CURRENT_SEASON_ID || '190'; // Use query param or default to High Stakes
+```
+
+To:
+
+```js
+    const programId = matchType && programMap[matchType] ? parseInt(programMap[matchType]) : 1;
+    const seasonId = season || await getCurrentSeasonId(pool, programId) || 197;
+```
+
+Note: `programId` is already computed a few lines below (line 1601). Move or reuse it. The key change is that VEXIQ teams will now get the correct VEXIQ season ID (196) instead of the VRC one (197).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/server.js
+git commit -m "refactor: replace hardcoded CURRENT_SEASON_ID with auto-detecting seasonResolver"
+```
+
+---
+
+### Task 6: Add Cron Job and Admin Endpoints
+
+**Files:**
+- Modify: `src/api/server.js:1-17` (imports)
+- Modify: `src/api/server.js:820-838` (server startup)
+- Modify: `src/api/server.js` (new endpoints, after existing admin routes around line 560)
+
+- [ ] **Step 1: Add imports**
+
+At the top of `src/api/server.js`, add these imports (alongside the seasonResolver import from Task 5):
+
+```js
+import cron from 'node-cron';
+import { runSkillsRefresh, refreshStatus } from './services/skillsRefresh.js';
+```
+
+- [ ] **Step 2: Add admin status endpoint**
+
+After the existing analysis admin endpoints (around line 563, after the SSE stream route), add:
+
+```js
+// Skills Refresh Status
+app.get('/api/admin/skills-refresh/status', authenticateToken, requireRole('admin'), (req, res) => {
+  res.json(refreshStatus);
+});
+
+// Skills Refresh Manual Trigger
+app.post('/api/admin/skills-refresh/trigger', authenticateToken, requireRole('admin'), (req, res) => {
+  if (refreshStatus.isRunning) {
+    return res.status(409).json({ error: 'Skills refresh already running' });
+  }
+
+  // Run in background — don't await
+  runSkillsRefresh(pool).catch(err => {
+    console.error('[skills-refresh] Manual trigger error:', err);
+  });
+
+  res.json({ message: 'Skills refresh started' });
+});
+```
+
+- [ ] **Step 3: Add cron job initialization in startServer**
+
+In the `startServer()` function, after `console.log('🚀 Server running...')` (inside the `app.listen` callback, around line 834), add:
+
+```js
+      // Start daily skills refresh cron job
+      const cronSchedule = process.env.SKILLS_REFRESH_CRON || '0 3 * * *';
+      cron.schedule(cronSchedule, () => {
+        console.log('[skills-refresh] Cron triggered');
+        runSkillsRefresh(pool).catch(err => {
+          console.error('[skills-refresh] Cron execution error:', err);
+        });
+      }, { timezone: 'UTC' });
+      console.log(`⏰ Skills refresh cron scheduled: ${cronSchedule} (UTC)`);
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api/server.js
+git commit -m "feat: add daily cron job and admin endpoints for skills refresh"
+```
+
+---
+
+### Task 7: Local Testing
+
+- [ ] **Step 1: Start the backend server locally**
+
+```bash
+npm run dev
+```
+
+Verify in the console output:
+- `⏰ Skills refresh cron scheduled: 0 3 * * *` appears
+- No errors related to `season_config` table creation
+- No errors from the new imports
+
+- [ ] **Step 2: Test season resolver via analysis worker**
+
+Use the admin panel or curl to trigger analysis — it should resolve the season ID from API → DB → memory:
+
+```bash
+# Check server logs for:
+# [season-resolver] VRC season resolved from API: 197 (VEX V5 Robotics Competition 2025-2026: Push Back)
+```
+
+- [ ] **Step 3: Test manual skills refresh trigger**
+
+```bash
+curl -X POST http://localhost:3000/api/admin/skills-refresh/trigger \
+  -H "Authorization: Bearer <your-admin-jwt-token>" \
+  -H "Content-Type: application/json"
+```
+
+Expected response: `{"message":"Skills refresh started"}`
+
+Watch the server logs for:
+```
+[skills-refresh] Starting scheduled refresh at ...
+[skills-refresh] Season IDs resolved — VRC: 197, VEXIQ: 196
+[skills-refresh] VRC High School: ~6824 records updated
+[skills-refresh] VRC Middle School: ~3173 records updated
+[skills-refresh] VEXIQ Middle School: ~6517 records updated
+[skills-refresh] VEXIQ Elementary School: ~2 records updated
+[skills-refresh] Completed in Xs — ~16516 total records, 0 retries, 0 failures
+```
+
+- [ ] **Step 4: Test status endpoint**
+
+```bash
+curl http://localhost:3000/api/admin/skills-refresh/status \
+  -H "Authorization: Bearer <your-admin-jwt-token>"
+```
+
+Expected: JSON with `lastRefreshedAt`, `isRunning: false`, and `lastResult` showing all 4 datasets.
+
+- [ ] **Step 5: Verify data in database**
+
+```bash
+# Check total records per matchType
+curl "http://localhost:3000/api/teams?matchType=VRC" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'VRC teams: {len(d)}')"
+curl "http://localhost:3000/api/teams?matchType=VEXIQ" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'VEXIQ teams: {len(d)}')"
+```
+
+- [ ] **Step 6: Verify season_config table was populated**
+
+```bash
+curl "http://localhost:3000/api/health"
+# Check server startup logs for:
+# [season-resolver] VRC season loaded from DB: 197
+# (On second restart, it should load from DB, not API)
+```
+
+- [ ] **Step 7: Commit any fixes from testing**
+
+```bash
+git add -A
+git commit -m "fix: address issues found during local testing"
+```
+
+---
+
+### Task 8: Push and Deploy
+
+- [ ] **Step 1: Push the feature branch**
+
+```bash
+git push -u origin feature/auto-skills-refresh
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --base main --title "feat: auto-refresh skills standings daily with season auto-detection" --body "$(cat <<'EOF'
+## Summary
+- Daily cron job fetches world skills standings from RobotEvents internal API and upserts into `skills_standings` — replaces manual CSV upload workflow
+- 3-tier season ID auto-detection (memory → DB → API → env var fallback) replaces hardcoded `CURRENT_SEASON_ID` across all usages
+- Admin endpoints for refresh status and manual trigger
+
+## Changes
+**New files:**
+- `src/api/services/seasonResolver.js` — shared season ID resolution with 3-tier cache
+- `src/api/services/skillsRefresh.js` — fetches 4 datasets (VRC HS/MS, VEXIQ MS/Elementary), retry logic, admin status
+
+**Modified files:**
+- `src/api/server.js` — new `season_config` table, cron setup, admin endpoints, replaced 3 hardcoded `CURRENT_SEASON_ID` references
+- `package.json` — added `node-cron`
+
+## Test plan
+- [ ] Manual trigger via `POST /api/admin/skills-refresh/trigger` — verify all 4 datasets upserted
+- [ ] Status endpoint returns correct counts and timing
+- [ ] Season auto-detection resolves correct IDs (VRC: 197, VEXIQ: 196)
+- [ ] Server restart loads season from DB cache (no API call)
+- [ ] Existing endpoints (performance, team events, analysis) work with auto-detected season IDs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge, verify on Railway**
+
+Check Railway Deploy Logs for:
+- `⏰ Skills refresh cron scheduled: 0 3 * * *`
+- No startup errors
+
+No new env vars required. The cron will fire at 3 AM UTC the next day. To verify immediately, use the manual trigger via the admin panel or curl against production.

--- a/docs/superpowers/specs/2026-04-13-auto-skills-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-skills-refresh-design.md
@@ -57,23 +57,34 @@ This mapping is identical to the existing CSV upload endpoint (`POST /api/upload
 
 A function `getCurrentSeasonId(programId)` used by the cron job and all existing season-dependent code.
 
-### Resolution Chain
+### Resolution Chain (3-tier cache)
 
 ```
-Step 1: Call RobotEvents v2 API
+Step 1: Check in-memory cache (Map object)
+        If exists → return immediately (zero I/O)
+
+Step 2: If memory cache empty → check season_config table in DB
+        If exists → save to memory cache, return
+
+Step 3: If DB empty → call RobotEvents v2 API
         GET /api/v2/seasons?program[]={programId}&per_page=5
         Pick the most recent season whose start date <= now
-        On success → save to season_config table (DB cache)
+        On success → save to DB + memory cache, return
 
-Step 2: If API fails → read last known good season ID from season_config table
-
-Step 3: If DB cache empty → fall back to env var
+Step 4: If API fails → fall back to env var
         VRC:   CURRENT_SEASON_ID
         VEXIQ: VEXIQ_SEASON_ID
 
-Step 4: If env var also missing → log [CRITICAL] error
+Step 5: If env var also missing → log [CRITICAL] error
         Skills refresh disabled for that program
 ```
+
+### Cache Lifecycle
+
+- **Memory cache** resets on server restart. First request after restart triggers a DB read (Step 2), then all subsequent calls are pure in-memory.
+- **DB cache** persists across restarts. Populated on first successful API call and never needs manual setup.
+- **Daily cron** is the only thing that calls the API to check for season changes. If the API returns a different season ID than what's cached, it updates both the DB and the memory cache.
+- **User-facing endpoints** (performance, team events, analysis) always resolve from memory — zero API calls, zero DB reads in normal operation.
 
 ### Database Table
 
@@ -109,8 +120,9 @@ Daily at 3:00 AM UTC. Configurable via `SKILLS_REFRESH_CRON` env var (default: `
 ### Execution Flow
 
 ```
-1. Resolve VRC season ID (via shared utility)
-2. Resolve VEXIQ season ID (via shared utility)
+1. Resolve VRC season ID (via shared utility — calls API directly, bypassing memory cache,
+   to check for season changes; updates DB + memory cache if changed)
+2. Resolve VEXIQ season ID (same as above)
 3. For each dataset (VRC HS, VRC MS, VEXIQ MS, VEXIQ Elementary):
    a. Fetch from RobotEvents internal API
    b. If fetch fails → wait 5s → retry once

--- a/docs/superpowers/specs/2026-04-13-auto-skills-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-skills-refresh-design.md
@@ -1,0 +1,205 @@
+# Auto Skills Refresh — Design Spec
+
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Problem
+
+World skills rankings in `skills_standings` are updated via manual CSV download from RobotEvents and upload through the admin panel. This requires visiting the standings page, downloading 4 separate CSV files (VRC HS, VRC MS, VEXIQ MS, VEXIQ Elementary), and uploading each one. Rankings go stale between manual refreshes.
+
+Additionally, `CURRENT_SEASON_ID` is hardcoded in env vars and must be manually updated each year when a new VRC season begins. Three places in `server.js` depend on it.
+
+## Solution
+
+A daily cron job in the Express server that fetches world skills standings from an undocumented RobotEvents internal API and upserts them into the database. A shared season auto-detection utility replaces all hardcoded season ID references.
+
+## Data Source
+
+RobotEvents internal API (no authentication required):
+
+```
+GET https://www.robotevents.com/api/seasons/{seasonId}/skills?post_season=0&grade_level={grade}
+```
+
+Returns a JSON array of all ranked teams for the given season and grade level.
+
+### Datasets
+
+| matchType | Program ID | Grade Level | ~Teams |
+|-----------|-----------|-------------|--------|
+| VRC       | 1         | High School | 6,824  |
+| VRC       | 1         | Middle School | 3,173 |
+| VEXIQ     | 41        | Middle School | 6,517 |
+| VEXIQ     | 41        | Elementary School | 2  |
+
+### Field Mapping (API → DB)
+
+| API JSON Path | DB Column | Type |
+|--------------|-----------|------|
+| `rank` | `rank` | INTEGER |
+| `scores.score` | `score` | INTEGER |
+| `scores.programming` | `autonomousSkills` | INTEGER |
+| `scores.driver` | `driverSkills` | INTEGER |
+| `scores.maxProgramming` | `highestAutonomousSkills` | INTEGER |
+| `scores.maxDriver` | `highestDriverSkills` | INTEGER |
+| `team.team` | `teamNumber` | TEXT |
+| `team.teamName` | `teamName` | TEXT |
+| `team.organization` | `organization` | TEXT |
+| `team.eventRegion` | `eventRegion` | TEXT |
+| `team.country` | `countryRegion` | TEXT |
+| (per dataset) | `matchType` | TEXT |
+
+This mapping is identical to the existing CSV upload endpoint (`POST /api/upload`).
+
+## Season Auto-Detection
+
+### Shared Utility
+
+A function `getCurrentSeasonId(programId)` used by the cron job and all existing season-dependent code.
+
+### Resolution Chain
+
+```
+Step 1: Call RobotEvents v2 API
+        GET /api/v2/seasons?program[]={programId}&per_page=5
+        Pick the most recent season whose start date <= now
+        On success → save to season_config table (DB cache)
+
+Step 2: If API fails → read last known good season ID from season_config table
+
+Step 3: If DB cache empty → fall back to env var
+        VRC:   CURRENT_SEASON_ID
+        VEXIQ: VEXIQ_SEASON_ID
+
+Step 4: If env var also missing → log [CRITICAL] error
+        Skills refresh disabled for that program
+```
+
+### Database Table
+
+```sql
+CREATE TABLE IF NOT EXISTS season_config (
+  program TEXT PRIMARY KEY,       -- 'VRC' or 'VEXIQ'
+  season_id INTEGER NOT NULL,
+  season_name TEXT,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### Existing Usages to Update
+
+All three existing usages of `CURRENT_SEASON_ID` in `server.js` will use the shared utility:
+
+| Line | Current Code | After |
+|------|-------------|-------|
+| 552 | `process.env.CURRENT_SEASON_ID \|\| 197` | `getCurrentSeasonId(1)` (VRC) |
+| 1226 | `process.env.CURRENT_SEASON_ID \|\| 197` | `getCurrentSeasonId(programId)` |
+| 1589 | `process.env.CURRENT_SEASON_ID \|\| '190'` | `getCurrentSeasonId(programId)` |
+
+## Cron Job
+
+### Schedule
+
+Daily at 3:00 AM UTC. Configurable via `SKILLS_REFRESH_CRON` env var (default: `0 3 * * *`).
+
+### Library
+
+`node-cron` — lightweight, no external dependencies.
+
+### Execution Flow
+
+```
+1. Resolve VRC season ID (via shared utility)
+2. Resolve VEXIQ season ID (via shared utility)
+3. For each dataset (VRC HS, VRC MS, VEXIQ MS, VEXIQ Elementary):
+   a. Fetch from RobotEvents internal API
+   b. If fetch fails → wait 5s → retry once
+   c. If retry also fails → log error, continue to next dataset
+   d. Upsert all records into skills_standings (same ON CONFLICT logic as CSV upload)
+   e. Log record count
+   f. Wait 1-2s before next dataset
+4. Log summary (total records, duration, retries, failures)
+5. Update in-memory status object
+```
+
+Each dataset is wrapped in its own database transaction.
+
+### Error Handling
+
+- Network/API failure: retry once after 5s delay, then skip and continue
+- Database error: rollback transaction for that dataset, continue with remaining
+- All errors logged with `[skills-refresh]` prefix for easy filtering in Railway logs
+
+## Admin Visibility
+
+### Status Endpoint
+
+`GET /api/admin/skills-refresh/status` (requires admin auth)
+
+```json
+{
+  "lastRefreshedAt": "2026-04-13T03:00:12Z",
+  "isRunning": false,
+  "lastResult": {
+    "duration": "12.3s",
+    "datasets": {
+      "VRC High School": { "records": 6824, "status": "success" },
+      "VRC Middle School": { "records": 3173, "status": "success" },
+      "VEXIQ Middle School": { "records": 6517, "status": "success", "retried": true },
+      "VEXIQ Elementary School": { "records": 2, "status": "success" }
+    },
+    "totalRecords": 16516,
+    "failures": 0
+  }
+}
+```
+
+### Manual Trigger
+
+`POST /api/admin/skills-refresh/trigger` (requires admin auth)
+
+Triggers the same refresh logic as the cron job. Returns immediately with `{ "message": "Refresh started" }`. Status can be polled via the status endpoint.
+
+### Log Output
+
+Visible in Railway Deploy Logs tab. Example:
+
+```
+[skills-refresh] Starting scheduled refresh at 2026-04-14T03:00:00Z
+[skills-refresh] Season IDs resolved — VRC: 197, VEXIQ: 196
+[skills-refresh] VRC High School: 6,824 records updated
+[skills-refresh] VRC Middle School: 3,173 records updated
+[skills-refresh] VEXIQ Middle School: FAILED (retrying in 5s...)
+[skills-refresh] VEXIQ Middle School (retry): 6,517 records updated
+[skills-refresh] VEXIQ Elementary School: 2 records updated
+[skills-refresh] Completed in 12.3s — 16,516 total records, 1 retry, 0 failures
+```
+
+## Dependencies
+
+### New Package
+
+- `node-cron` — cron scheduler for Node.js
+
+### Environment Variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `SKILLS_REFRESH_CRON` | No | `0 3 * * *` | Cron schedule expression |
+| `CURRENT_SEASON_ID` | No | Auto-detected | VRC season fallback |
+| `VEXIQ_SEASON_ID` | No | Auto-detected | VEXIQ season fallback |
+
+No changes to existing env vars. No new required env vars.
+
+## Deployment
+
+### Railway (Backend)
+
+- Push to `main` → auto-deploys
+- No new env vars required (all optional)
+- No database migration needed (table created via `CREATE TABLE IF NOT EXISTS` at startup)
+- Cron starts automatically with the server
+
+### Vercel (Frontend)
+
+- No changes needed — this is entirely backend

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,13 @@
         "jsonwebtoken": "^9.0.2",
         "mathjs": "^15.1.0",
         "multer": "^1.4.5-lts.1",
+        "node-cron": "^4.2.1",
         "node-fetch": "^3.3.2",
-        "pg": "^8.11.3"
+        "pg": "^8.11.3",
+        "pino": "^8.21.0"
+      },
+      "devDependencies": {
+        "pino-pretty": "^11.3.0"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -33,6 +38,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -58,6 +75,35 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/bcryptjs": {
@@ -88,6 +134,30 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -150,6 +220,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/complex.js": {
       "version": "2.4.3",
@@ -255,6 +332,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -339,6 +426,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -388,6 +485,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -450,6 +565,29 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -617,6 +755,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -645,6 +790,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -671,6 +836,16 @@
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
       "license": "MIT"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -910,6 +1085,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -969,6 +1153,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -979,6 +1172,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/parseurl": {
@@ -1085,6 +1288,142 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
+      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -1124,10 +1463,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -1141,6 +1495,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1157,6 +1522,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -1203,6 +1574,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1223,11 +1603,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -1379,6 +1775,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -1419,6 +1824,28 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
@@ -1504,6 +1931,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,16 @@
     "jsonwebtoken": "^9.0.2",
     "mathjs": "^15.1.0",
     "multer": "^1.4.5-lts.1",
+    "node-cron": "^4.2.1",
     "node-fetch": "^3.3.2",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "pino": "^8.21.0"
   },
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=8.0.0"
+  },
+  "devDependencies": {
+    "pino-pretty": "^11.3.0"
   }
 }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -405,6 +405,16 @@ async function initializeDatabase() {
       )
     `);
 
+    // Create season_config table for caching auto-detected season IDs
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS season_config (
+        program TEXT PRIMARY KEY,
+        season_id INTEGER NOT NULL,
+        season_name TEXT,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
     // Insert default roles if they don't exist
     await pool.query(`
       INSERT INTO roles (name, description) VALUES 

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -15,6 +15,7 @@ import jwt from 'jsonwebtoken';
 import { ensureTeamAnalysis, getTeamPerformance } from './services/analysis.js';
 import { analysisWorker } from './services/analysis-worker.js';
 import { publicLimiter, authLimiter, adminLimiter } from './middleware/rateLimiter.js';
+import { getCurrentSeasonId } from './services/seasonResolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -551,7 +552,7 @@ app.get('/api/admin/analysis/status', authenticateToken, requireRole('admin'), (
 });
 
 // 2. Start Analysis
-app.post('/api/admin/analysis/start', authenticateToken, requireRole('admin'), (req, res) => {
+app.post('/api/admin/analysis/start', authenticateToken, requireRole('admin'), async (req, res) => {
   if (analysisWorker.isRunning) {
     return res.status(409).json({ error: 'Analysis already running' });
   }
@@ -559,7 +560,8 @@ app.post('/api/admin/analysis/start', authenticateToken, requireRole('admin'), (
   const { force } = req.body;
 
   // Start in background
-  analysisWorker.start(pool, process.env.ROBOTEVENTS_API_TOKEN, process.env.CURRENT_SEASON_ID || 197, !!force);
+  const seasonId = await getCurrentSeasonId(pool, 1); // VRC
+  analysisWorker.start(pool, process.env.ROBOTEVENTS_API_TOKEN, seasonId || 197, !!force);
 
   res.json({ success: true, message: 'Analysis started' });
 });
@@ -1233,7 +1235,7 @@ app.get('/api/analysis/performance', async (req, res) => {
     }
 
     const teamList = teams.split(',').map(t => t.trim());
-    const seasonId = req.query.season || process.env.CURRENT_SEASON_ID || 197; // Default to current VRC season
+    const seasonId = req.query.season || await getCurrentSeasonId(pool, 1) || 197;
 
     // 1. Ensure caching (Trigger orchestrator)
     // 1. Ensure caching: SKIPPED
@@ -1595,8 +1597,6 @@ app.get('/api/teams/:teamNumber/events', async (req, res) => {
     const { teamNumber } = req.params;
     const { season, matchType } = req.query;
 
-    // Get the current season ID and API token from environment
-    const seasonId = season || process.env.CURRENT_SEASON_ID || '190'; // Use query param or default to High Stakes
     const apiToken = process.env.ROBOTEVENTS_API_TOKEN;
 
     // Map matchType to RobotEvents program ID
@@ -1606,6 +1606,9 @@ app.get('/api/teams/:teamNumber/events', async (req, res) => {
       'VEXIQ': '41',   // VEX IQ Robotics Competition (NOT 4!)
       'VEXU': '4'      // VEX U Robotics Competition (NOT 41!)
     };
+
+    const resolvedProgramId = matchType && programMap[matchType] ? parseInt(programMap[matchType]) : 1;
+    const seasonId = season || await getCurrentSeasonId(pool, resolvedProgramId) || 197;
 
     // Get program ID from matchType, default to VRC if not provided
     const programId = matchType && programMap[matchType] ? programMap[matchType] : '1';

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,8 @@ import { ensureTeamAnalysis, getTeamPerformance } from './services/analysis.js';
 import { analysisWorker } from './services/analysis-worker.js';
 import { publicLimiter, authLimiter, adminLimiter } from './middleware/rateLimiter.js';
 import { getCurrentSeasonId } from './services/seasonResolver.js';
+import cron from 'node-cron';
+import { runSkillsRefresh, refreshStatus } from './services/skillsRefresh.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -612,6 +614,25 @@ app.get('/api/admin/analysis/stream', (req, res) => {
   });
 });
 
+// Skills Refresh Status
+app.get('/api/admin/skills-refresh/status', authenticateToken, requireRole('admin'), (req, res) => {
+  res.json(refreshStatus);
+});
+
+// Skills Refresh Manual Trigger
+app.post('/api/admin/skills-refresh/trigger', authenticateToken, requireRole('admin'), (req, res) => {
+  if (refreshStatus.isRunning) {
+    return res.status(409).json({ error: 'Skills refresh already running' });
+  }
+
+  // Run in background — don't await
+  runSkillsRefresh(pool).catch(err => {
+    console.error('[skills-refresh] Manual trigger error:', err);
+  });
+
+  res.json({ message: 'Skills refresh started' });
+});
+
 // 5. Manage Tracked Teams (Get)
 app.get('/api/admin/tracked-teams', authenticateToken, requireRole('admin'), async (req, res) => {
   try {
@@ -847,6 +868,16 @@ async function startServer() {
       console.log(`📊 API endpoints available at http://0.0.0.0:${PORT}/api`);
       console.log(`🌍 Environment: ${process.env.NODE_ENV || 'development'}`);
       console.log(`🔗 Database: ${process.env.DATABASE_URL ? 'Railway PostgreSQL' : 'Local connection'}`);
+
+      // Start daily skills refresh cron job
+      const cronSchedule = process.env.SKILLS_REFRESH_CRON || '0 3 * * *';
+      cron.schedule(cronSchedule, () => {
+        console.log('[skills-refresh] Cron triggered');
+        runSkillsRefresh(pool).catch(err => {
+          console.error('[skills-refresh] Cron execution error:', err);
+        });
+      }, { timezone: 'UTC' });
+      console.log(`⏰ Skills refresh cron scheduled: ${cronSchedule} (UTC)`);
     });
 
     // Handle server startup errors

--- a/src/api/services/seasonResolver.js
+++ b/src/api/services/seasonResolver.js
@@ -86,9 +86,16 @@ export async function refreshSeasonId(pool, programId) {
     return apiResult.seasonId;
   }
 
-  // API failed — fall back to getCurrentSeasonId which tries DB → env
+  // API failed — fall back to DB cache or env var directly (skip API retry)
   console.warn(`[season-resolver] API refresh failed for ${config.key}, falling back to cached value`);
-  return getCurrentSeasonId(pool, programId);
+  try {
+    const dbResult = await pool.query('SELECT season_id FROM season_config WHERE program = $1', [config.key]);
+    if (dbResult.rows.length > 0) return dbResult.rows[0].season_id;
+  } catch (err) {
+    console.error(`[season-resolver] DB fallback read failed for ${config.key}:`, err.message);
+  }
+  const envValue = process.env[config.envVar];
+  return envValue ? parseInt(envValue) : null;
 }
 
 /**
@@ -121,7 +128,9 @@ async function fetchSeasonFromApi(programId) {
     const data = await response.json();
     const now = new Date();
 
-    for (const season of data.data) {
+    // Sort by start date descending to ensure we pick the most recent started season
+    const seasons = data.data.sort((a, b) => new Date(b.start) - new Date(a.start));
+    for (const season of seasons) {
       const start = new Date(season.start);
       if (now >= start) {
         return { seasonId: season.id, seasonName: season.name };

--- a/src/api/services/seasonResolver.js
+++ b/src/api/services/seasonResolver.js
@@ -1,0 +1,155 @@
+// src/api/services/seasonResolver.js
+import fetch from 'node-fetch';
+
+// In-memory cache: Map<programKey, { seasonId, seasonName }>
+// programKey is 'VRC' or 'VEXIQ'
+const seasonCache = new Map();
+
+// Map program IDs to keys and env var names
+const PROGRAM_CONFIG = {
+  1:  { key: 'VRC',   envVar: 'CURRENT_SEASON_ID' },
+  41: { key: 'VEXIQ', envVar: 'VEXIQ_SEASON_ID' },
+};
+
+/**
+ * Get the current season ID for a program.
+ * Resolution: memory cache → DB → API → env var → critical error.
+ */
+export async function getCurrentSeasonId(pool, programId) {
+  const config = PROGRAM_CONFIG[programId];
+  if (!config) {
+    console.error(`[season-resolver] Unknown program ID: ${programId}`);
+    return null;
+  }
+
+  // Tier 1: Memory cache
+  if (seasonCache.has(config.key)) {
+    return seasonCache.get(config.key).seasonId;
+  }
+
+  // Tier 2: Database
+  try {
+    const result = await pool.query(
+      'SELECT season_id, season_name FROM season_config WHERE program = $1',
+      [config.key]
+    );
+    if (result.rows.length > 0) {
+      const { season_id, season_name } = result.rows[0];
+      seasonCache.set(config.key, { seasonId: season_id, seasonName: season_name });
+      console.log(`[season-resolver] ${config.key} season loaded from DB: ${season_id} (${season_name})`);
+      return season_id;
+    }
+  } catch (err) {
+    console.error(`[season-resolver] DB read failed for ${config.key}:`, err.message);
+  }
+
+  // Tier 3: API
+  const apiResult = await fetchSeasonFromApi(programId);
+  if (apiResult) {
+    await saveSeasonToDb(pool, config.key, apiResult.seasonId, apiResult.seasonName);
+    seasonCache.set(config.key, apiResult);
+    console.log(`[season-resolver] ${config.key} season resolved from API: ${apiResult.seasonId} (${apiResult.seasonName})`);
+    return apiResult.seasonId;
+  }
+
+  // Tier 4: Environment variable fallback
+  const envValue = process.env[config.envVar];
+  if (envValue) {
+    const seasonId = parseInt(envValue);
+    seasonCache.set(config.key, { seasonId, seasonName: 'from env var' });
+    console.warn(`[season-resolver] ${config.key} season using env var fallback: ${seasonId}`);
+    return seasonId;
+  }
+
+  // Tier 5: Critical error
+  console.error(`[CRITICAL] Could not determine ${config.key} season ID. No API, DB, or env var available.`);
+  return null;
+}
+
+/**
+ * Refresh the season ID by calling the API directly (bypasses memory cache).
+ * Used by the daily cron to detect season changes.
+ * Updates DB and memory cache if the season has changed.
+ */
+export async function refreshSeasonId(pool, programId) {
+  const config = PROGRAM_CONFIG[programId];
+  if (!config) return null;
+
+  const apiResult = await fetchSeasonFromApi(programId);
+  if (apiResult) {
+    const cached = seasonCache.get(config.key);
+    if (!cached || cached.seasonId !== apiResult.seasonId) {
+      console.log(`[season-resolver] ${config.key} season changed: ${cached?.seasonId || 'none'} → ${apiResult.seasonId} (${apiResult.seasonName})`);
+      await saveSeasonToDb(pool, config.key, apiResult.seasonId, apiResult.seasonName);
+    }
+    seasonCache.set(config.key, apiResult);
+    return apiResult.seasonId;
+  }
+
+  // API failed — fall back to getCurrentSeasonId which tries DB → env
+  console.warn(`[season-resolver] API refresh failed for ${config.key}, falling back to cached value`);
+  return getCurrentSeasonId(pool, programId);
+}
+
+/**
+ * Fetch the current season from RobotEvents v2 API.
+ * Picks the most recent season whose start date is in the past.
+ */
+async function fetchSeasonFromApi(programId) {
+  const apiToken = process.env.ROBOTEVENTS_API_TOKEN;
+  if (!apiToken) {
+    console.warn('[season-resolver] No ROBOTEVENTS_API_TOKEN configured, skipping API lookup');
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.robotevents.com/api/v2/seasons?program[]=${programId}&per_page=5`,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiToken}`,
+          'Accept': 'application/json'
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error(`[season-resolver] API returned ${response.status} for program ${programId}`);
+      return null;
+    }
+
+    const data = await response.json();
+    const now = new Date();
+
+    for (const season of data.data) {
+      const start = new Date(season.start);
+      if (now >= start) {
+        return { seasonId: season.id, seasonName: season.name };
+      }
+    }
+
+    console.warn(`[season-resolver] No started season found for program ${programId}`);
+    return null;
+  } catch (err) {
+    console.error(`[season-resolver] API fetch failed for program ${programId}:`, err.message);
+    return null;
+  }
+}
+
+/**
+ * Save a season ID to the database (upsert).
+ */
+async function saveSeasonToDb(pool, programKey, seasonId, seasonName) {
+  try {
+    await pool.query(`
+      INSERT INTO season_config (program, season_id, season_name, updated_at)
+      VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+      ON CONFLICT (program) DO UPDATE SET
+        season_id = EXCLUDED.season_id,
+        season_name = EXCLUDED.season_name,
+        updated_at = CURRENT_TIMESTAMP
+    `, [programKey, seasonId, seasonName]);
+  } catch (err) {
+    console.error(`[season-resolver] Failed to save season to DB:`, err.message);
+  }
+}

--- a/src/api/services/skillsRefresh.js
+++ b/src/api/services/skillsRefresh.js
@@ -14,7 +14,7 @@ const DATASETS = [
   { matchType: 'VRC',   programId: 1,  gradeLevel: 'High School',       label: 'VRC High School' },
   { matchType: 'VRC',   programId: 1,  gradeLevel: 'Middle School',     label: 'VRC Middle School' },
   { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Middle School',     label: 'VEXIQ Middle School' },
-  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Elementary School', label: 'VEXIQ Elementary School' },
+  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Elementary',        label: 'VEXIQ Elementary School' },
 ];
 
 /**

--- a/src/api/services/skillsRefresh.js
+++ b/src/api/services/skillsRefresh.js
@@ -1,0 +1,195 @@
+// src/api/services/skillsRefresh.js
+import fetch from 'node-fetch';
+import { refreshSeasonId } from './seasonResolver.js';
+
+// In-memory status for admin visibility
+export const refreshStatus = {
+  lastRefreshedAt: null,
+  isRunning: false,
+  lastResult: null,
+};
+
+// Dataset configurations
+const DATASETS = [
+  { matchType: 'VRC',   programId: 1,  gradeLevel: 'High School',       label: 'VRC High School' },
+  { matchType: 'VRC',   programId: 1,  gradeLevel: 'Middle School',     label: 'VRC Middle School' },
+  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Middle School',     label: 'VEXIQ Middle School' },
+  { matchType: 'VEXIQ', programId: 41, gradeLevel: 'Elementary School', label: 'VEXIQ Elementary School' },
+];
+
+/**
+ * Run the full skills refresh cycle.
+ * Resolves season IDs, fetches 4 datasets, upserts into skills_standings.
+ */
+export async function runSkillsRefresh(pool) {
+  if (refreshStatus.isRunning) {
+    console.log('[skills-refresh] Already running, skipping');
+    return;
+  }
+
+  refreshStatus.isRunning = true;
+  const startTime = Date.now();
+  const results = {};
+  let totalRecords = 0;
+  let failures = 0;
+  let retries = 0;
+
+  console.log(`[skills-refresh] Starting scheduled refresh at ${new Date().toISOString()}`);
+
+  // Step 1: Resolve season IDs (calls API directly to detect changes)
+  const vrcSeasonId = await refreshSeasonId(pool, 1);
+  const vexiqSeasonId = await refreshSeasonId(pool, 41);
+
+  console.log(`[skills-refresh] Season IDs resolved — VRC: ${vrcSeasonId}, VEXIQ: ${vexiqSeasonId}`);
+
+  // Step 2: Process each dataset
+  for (const dataset of DATASETS) {
+    const seasonId = dataset.programId === 1 ? vrcSeasonId : vexiqSeasonId;
+
+    if (!seasonId) {
+      console.error(`[skills-refresh] ${dataset.label}: SKIPPED — no season ID available`);
+      results[dataset.label] = { records: 0, status: 'skipped' };
+      failures++;
+      continue;
+    }
+
+    const result = await fetchAndUpsertDataset(pool, seasonId, dataset);
+    results[dataset.label] = result;
+
+    if (result.status === 'success') {
+      totalRecords += result.records;
+      if (result.retried) retries++;
+    } else {
+      failures++;
+    }
+
+    // Wait 1.5s between datasets to avoid hammering the server
+    if (DATASETS.indexOf(dataset) < DATASETS.length - 1) {
+      await sleep(1500);
+    }
+  }
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  refreshStatus.lastRefreshedAt = new Date().toISOString();
+  refreshStatus.isRunning = false;
+  refreshStatus.lastResult = {
+    duration: `${duration}s`,
+    datasets: results,
+    totalRecords,
+    failures,
+    retries,
+  };
+
+  console.log(`[skills-refresh] Completed in ${duration}s — ${totalRecords} total records, ${retries} retries, ${failures} failures`);
+}
+
+/**
+ * Fetch a single dataset from RobotEvents and upsert into skills_standings.
+ * Retries once on failure.
+ */
+async function fetchAndUpsertDataset(pool, seasonId, dataset) {
+  let data = null;
+  let retried = false;
+
+  // Attempt 1
+  data = await fetchSkillsData(seasonId, dataset.gradeLevel);
+
+  // Retry once on failure
+  if (!data) {
+    console.warn(`[skills-refresh] ${dataset.label}: FAILED (retrying in 5s...)`);
+    retried = true;
+    await sleep(5000);
+    data = await fetchSkillsData(seasonId, dataset.gradeLevel);
+  }
+
+  if (!data) {
+    console.error(`[skills-refresh] ${dataset.label}: FAILED after retry`);
+    return { records: 0, status: 'failed', retried };
+  }
+
+  // Upsert into database
+  try {
+    await pool.query('BEGIN');
+
+    for (const record of data) {
+      await pool.query(`
+        INSERT INTO skills_standings (
+          teamNumber, teamName, organization, eventRegion, countryRegion,
+          rank, score, autonomousSkills, driverSkills,
+          highestAutonomousSkills, highestDriverSkills, matchType
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ON CONFLICT (teamNumber, matchType) DO UPDATE SET
+          teamName = EXCLUDED.teamName,
+          organization = EXCLUDED.organization,
+          eventRegion = EXCLUDED.eventRegion,
+          countryRegion = EXCLUDED.countryRegion,
+          rank = EXCLUDED.rank,
+          score = EXCLUDED.score,
+          autonomousSkills = EXCLUDED.autonomousSkills,
+          driverSkills = EXCLUDED.driverSkills,
+          highestAutonomousSkills = EXCLUDED.highestAutonomousSkills,
+          highestDriverSkills = EXCLUDED.highestDriverSkills,
+          lastUpdated = CURRENT_TIMESTAMP
+      `, [
+        record.team.team,
+        record.team.teamName,
+        record.team.organization,
+        record.team.eventRegion || '',
+        record.team.country || '',
+        record.rank,
+        record.scores.score,
+        record.scores.programming,
+        record.scores.driver,
+        record.scores.maxProgramming,
+        record.scores.maxDriver,
+        dataset.matchType,
+      ]);
+    }
+
+    await pool.query('COMMIT');
+    console.log(`[skills-refresh] ${dataset.label}: ${data.length} records updated`);
+    return { records: data.length, status: 'success', retried };
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    console.error(`[skills-refresh] ${dataset.label}: DB error — ${err.message}`);
+    return { records: 0, status: 'failed', retried };
+  }
+}
+
+/**
+ * Fetch skills standings from the RobotEvents internal API.
+ * This is an undocumented API that does not require authentication.
+ */
+async function fetchSkillsData(seasonId, gradeLevel) {
+  try {
+    const url = `https://www.robotevents.com/api/seasons/${seasonId}/skills?post_season=0&grade_level=${encodeURIComponent(gradeLevel)}`;
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      }
+    });
+
+    if (!response.ok) {
+      console.error(`[skills-refresh] API returned ${response.status} for season ${seasonId}, grade ${gradeLevel}`);
+      return null;
+    }
+
+    const data = await response.json();
+
+    if (!Array.isArray(data)) {
+      console.error(`[skills-refresh] Unexpected response format for season ${seasonId}, grade ${gradeLevel}`);
+      return null;
+    }
+
+    return data;
+  } catch (err) {
+    console.error(`[skills-refresh] Fetch error for season ${seasonId}, grade ${gradeLevel}:`, err.message);
+    return null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Daily cron job fetches world skills standings from RobotEvents internal API and upserts into `skills_standings` — replaces manual CSV upload workflow
- 3-tier season ID auto-detection (memory → DB → API → env var fallback) replaces hardcoded `CURRENT_SEASON_ID` across all usages
- Admin endpoints for refresh status and manual trigger

## New Files
- `src/api/services/seasonResolver.js` — shared season ID resolution with 3-tier cache (memory → DB → API → env var)
- `src/api/services/skillsRefresh.js` — fetches 4 datasets (VRC HS/MS, VEXIQ MS/Elementary), retry logic, admin status

## Changes to server.js
- New `season_config` DB table for caching season IDs
- Cron job scheduled daily at 3 AM UTC (configurable via `SKILLS_REFRESH_CRON` env var)
- `GET /api/admin/skills-refresh/status` — last refresh time, running state, per-dataset results
- `POST /api/admin/skills-refresh/trigger` — manual trigger
- Replaced 3 hardcoded `CURRENT_SEASON_ID` usages with auto-detecting `getCurrentSeasonId()`

## How It Works
The RobotEvents internal API (`/api/seasons/{id}/skills`) returns the full world rankings with no auth required. The cron fetches all ~16,500 teams across 4 grade levels and upserts them daily. Season IDs are auto-detected by picking the most recent season whose start date is in the past — no manual config needed when seasons roll over each year.

## Test Plan
- [ ] Server starts with `⏰ Skills refresh cron scheduled: 0 3 * * * (UTC)` in logs
- [ ] `POST /api/admin/skills-refresh/trigger` fetches all 4 datasets (~16,500 records)
- [ ] `GET /api/admin/skills-refresh/status` returns correct timing and dataset counts
- [ ] Season IDs auto-detected (VRC: 197, VEXIQ: 196)
- [ ] On server restart, season IDs load from DB cache (no API call)
- [ ] Existing endpoints (performance, team events, analysis) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)