### PR TITLE
feat: automated daily world skills rankings refresh

### DIFF
--- a/frontend-nextjs/src/app/compare/page.tsx
+++ b/frontend-nextjs/src/app/compare/page.tsx
@@ -195,7 +195,7 @@ export default function ComparePage() {
                     onRemove={() => removeFromCompare(team.teamNumber)}
                     onFavorite={() => handleFavoriteClick(team)}
                     isFavorite={isFavorite(team.teamNumber)}
-                    onClick={() => router.push(`/team/${team.teamNumber}`)}
+                    onClick={() => router.push(`/team/${team.teamNumber}?matchType=${encodeURIComponent(team.matchType)}`)}
                     getMatchTypeBadgeColor={getMatchTypeBadgeColor}
                   />
                 </motion.div>

--- a/frontend-nextjs/src/app/favorites/page.tsx
+++ b/frontend-nextjs/src/app/favorites/page.tsx
@@ -230,7 +230,7 @@ export default function FavoritesPage() {
                   onCompare={handleCompareClick}
                   isInCompare={isInCompare(team.teamNumber)}
                   canAddToCompare={canAddToCompare}
-                  onClick={() => router.push(`/team/${team.teamNumber}`)}
+                  onClick={() => router.push(`/team/${team.teamNumber}?matchType=${encodeURIComponent(team.matchType)}`)}
                   getMatchTypeBadgeColor={getMatchTypeBadgeColor}
                 />
               </motion.div>

--- a/frontend-nextjs/src/app/page.tsx
+++ b/frontend-nextjs/src/app/page.tsx
@@ -392,7 +392,7 @@ function HomeContent() {
                       team={team} 
                       onClick={() => {
                         const currentUrl = window.location.pathname + window.location.search;
-                        router.push(`/team/${team.teamNumber}?returnUrl=${encodeURIComponent(currentUrl)}`);
+                        router.push(`/team/${team.teamNumber}?matchType=${encodeURIComponent(team.matchType)}&returnUrl=${encodeURIComponent(currentUrl)}`);
                       }} 
                     />
                   </motion.div>

--- a/frontend-nextjs/src/app/team/[teamNumber]/page.tsx
+++ b/frontend-nextjs/src/app/team/[teamNumber]/page.tsx
@@ -27,24 +27,29 @@ export default function TeamDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const teamNumber = params.teamNumber as string;
+  const matchTypeParam = searchParams.get('matchType') || undefined;
   const [mounted, setMounted] = useState(false);
   const [selectedSeasonId, setSelectedSeasonId] = useState<string | null>(null);
-  
+
   useEffect(() => {
     setMounted(true);
   }, []);
-  
-  const { data: team, isLoading: isTeamLoading, error: teamError } = useTeam(teamNumber);
+
+  const { data: team, isLoading: isTeamLoading, error: teamError } = useTeam(teamNumber, matchTypeParam);
   
   // Fetch seasons for the team's specific program (VRC, VEXIQ, or VEXU)
   // This ensures we get the correct seasons for the team's program
   const { data: seasons, isLoading: isSeasonsLoading } = useSeasons(team?.matchType);
   
-  // Auto-select current season when seasons load
-  // The seasons array is sorted by most recent first, so seasons[0] = current season
+  // Auto-select current season when seasons load.
+  // The seasons array is sorted by start date descending, but RobotEvents sometimes
+  // publishes an upcoming season before it begins, so seasons[0] can be a future
+  // season with no events. Pick the first one that has actually started.
   useEffect(() => {
     if (seasons && seasons.length > 0 && selectedSeasonId === null) {
-      setSelectedSeasonId(seasons[0].id.toString());
+      const now = Date.now();
+      const current = seasons.find(s => new Date(s.start).getTime() <= now) ?? seasons[0];
+      setSelectedSeasonId(current.id.toString());
     }
   }, [seasons, selectedSeasonId]);
   

--- a/frontend-nextjs/src/hooks/useTeam.ts
+++ b/frontend-nextjs/src/hooks/useTeam.ts
@@ -3,11 +3,12 @@ import type { Team } from '@/types/skills';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
-export function useTeam(teamNumber: string) {
+export function useTeam(teamNumber: string, matchType?: string) {
   return useQuery<Team>({
-    queryKey: ['team', teamNumber],
+    queryKey: ['team', teamNumber, matchType],
     queryFn: async () => {
-      const response = await fetch(`${API_BASE_URL}/api/teams/${encodeURIComponent(teamNumber)}`);
+      const params = matchType ? `?matchType=${encodeURIComponent(matchType)}` : '';
+      const response = await fetch(`${API_BASE_URL}/api/teams/${encodeURIComponent(teamNumber)}${params}`);
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || 'Failed to fetch team details');

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1221,7 +1221,14 @@ app.get('/api/teams', async (req, res) => {
 // Get team by number
 app.get('/api/teams/:teamNumber', async (req, res) => {
   try {
-    const result = await pool.query('SELECT * FROM skills_standings WHERE teamNumber = $1', [req.params.teamNumber]);
+    const { matchType } = req.query;
+    let query = 'SELECT * FROM skills_standings WHERE teamNumber = $1';
+    const params = [req.params.teamNumber];
+    if (matchType) {
+      query += ' AND matchType = $2';
+      params.push(matchType);
+    }
+    const result = await pool.query(query, params);
     if (result.rows.length === 0) {
       res.status(404).json({ error: 'Team not found' });
     } else {

--- a/src/api/services/seasonResolver.js
+++ b/src/api/services/seasonResolver.js
@@ -128,13 +128,32 @@ async function fetchSeasonFromApi(programId) {
     const data = await response.json();
     const now = new Date();
 
-    // Sort by start date descending to ensure we pick the most recent started season
-    const seasons = data.data.sort((a, b) => new Date(b.start) - new Date(a.start));
-    for (const season of seasons) {
-      const start = new Date(season.start);
-      if (now >= start) {
-        return { seasonId: season.id, seasonName: season.name };
-      }
+    // Prefer seasons that currently bracket today (start <= now <= end).
+    // RobotEvents sometimes publishes an upcoming season's start date early,
+    // which would otherwise beat the real current season if we only checked start.
+    // Among currently-active seasons, pick the one ending soonest — that's the
+    // real current season (the other overlapping one is the upcoming one).
+    const active = data.data.filter(s => {
+      const start = new Date(s.start);
+      const end = s.end ? new Date(s.end) : null;
+      return now >= start && (!end || now <= end);
+    }).sort((a, b) => {
+      const aEnd = a.end ? new Date(a.end) : new Date(8640000000000000);
+      const bEnd = b.end ? new Date(b.end) : new Date(8640000000000000);
+      return aEnd - bEnd;
+    });
+
+    if (active.length > 0) {
+      return { seasonId: active[0].id, seasonName: active[0].name };
+    }
+
+    // Fallback: no season brackets today — pick the most recently started one
+    const fallback = [...data.data]
+      .sort((a, b) => new Date(b.start) - new Date(a.start))
+      .find(s => now >= new Date(s.start));
+    if (fallback) {
+      console.warn(`[season-resolver] No active season brackets today for program ${programId}, using most recent started: ${fallback.id} (${fallback.name})`);
+      return { seasonId: fallback.id, seasonName: fallback.name };
     }
 
     console.warn(`[season-resolver] No started season found for program ${programId}`);

--- a/src/api/services/seasonResolver.js
+++ b/src/api/services/seasonResolver.js
@@ -128,32 +128,13 @@ async function fetchSeasonFromApi(programId) {
     const data = await response.json();
     const now = new Date();
 
-    // Prefer seasons that currently bracket today (start <= now <= end).
-    // RobotEvents sometimes publishes an upcoming season's start date early,
-    // which would otherwise beat the real current season if we only checked start.
-    // Among currently-active seasons, pick the one ending soonest — that's the
-    // real current season (the other overlapping one is the upcoming one).
-    const active = data.data.filter(s => {
-      const start = new Date(s.start);
-      const end = s.end ? new Date(s.end) : null;
-      return now >= start && (!end || now <= end);
-    }).sort((a, b) => {
-      const aEnd = a.end ? new Date(a.end) : new Date(8640000000000000);
-      const bEnd = b.end ? new Date(b.end) : new Date(8640000000000000);
-      return aEnd - bEnd;
-    });
-
-    if (active.length > 0) {
-      return { seasonId: active[0].id, seasonName: active[0].name };
-    }
-
-    // Fallback: no season brackets today — pick the most recently started one
-    const fallback = [...data.data]
-      .sort((a, b) => new Date(b.start) - new Date(a.start))
-      .find(s => now >= new Date(s.start));
-    if (fallback) {
-      console.warn(`[season-resolver] No active season brackets today for program ${programId}, using most recent started: ${fallback.id} (${fallback.name})`);
-      return { seasonId: fallback.id, seasonName: fallback.name };
+    // Sort by start date descending to ensure we pick the most recent started season
+    const seasons = data.data.sort((a, b) => new Date(b.start) - new Date(a.start));
+    for (const season of seasons) {
+      const start = new Date(season.start);
+      if (now >= start) {
+        return { seasonId: season.id, seasonName: season.name };
+      }
     }
 
     console.warn(`[season-resolver] No started season found for program ${programId}`);


### PR DESCRIPTION
## Summary

- **Auto-refresh world skills standings daily** via a `node-cron` job (3 AM UTC) — eliminates the need to manually download and upload 4 CSV files from RobotEvents
- **Auto-detect current season ID** using RobotEvents v2 API with a 3-tier cache: in-memory → DB (`season_config` table) → env var fallback
- **Fix: VRC/VEXIQ team collision** — teams with the same number in different programs (e.g., 252A in both VRC and VEXIQ) now correctly scope lookups by `matchType`
- **Fix: Default season on team details page** — no longer defaults to a future season (2026-2027) that has no events; picks the first season that has actually started
- **Fix: VEXIQ Elementary grade_level parameter** — `Elementary School` → `Elementary` (was returning only 2 records instead of 6,636)

## New files
- `src/api/services/seasonResolver.js` — 3-tier season ID cache with `getCurrentSeasonId` and `refreshSeasonId`
- `src/api/services/skillsRefresh.js` — fetches 4 datasets from RobotEvents internal API, upserts into `skills_standings`, retry logic, status tracking

## Admin endpoints
- `GET /api/admin/skills-refresh/status` — view last run result, running state, timestamp
- `POST /api/admin/skills-refresh/trigger` — manually trigger a refresh (requires admin JWT)

## DB migration
No manual migration needed — `season_config` table is created automatically on server startup via `CREATE TABLE IF NOT EXISTS`.

## Post-deploy steps
1. Trigger a manual refresh to populate `season_config` with correct season IDs:
   ```
   POST /api/admin/skills-refresh/trigger
   ```
2. Verify `season_config` has 2 rows: VRC → 197, VEXIQ → 196

## Test plan
- [x] Verified all 4 datasets fetch correctly on production (23,150 total records, 0 failures)
- [x] VEXIQ Elementary: 6,636 records ✓
- [x] Season IDs auto-detected: VRC=197 (Push Back), VEXIQ=196 (Mix & Match)
- [ ] Merge and confirm Railway auto-deploys
- [ ] Trigger manual refresh post-deploy, verify `season_config` rows
- [ ] Confirm team detail page defaults to current season (not 2026-2027)
- [ ] Confirm VRC team 252A shows VRC data, not VEXIQ data

🤖 Generated with [Claude Code](https://claude.com/claude-code)