### PR TITLE
fix: forward divisionId to event rankings from match list page

### DIFF
--- a/frontend-nextjs/src/app/team/[teamNumber]/event/[eventId]/page.tsx
+++ b/frontend-nextjs/src/app/team/[teamNumber]/event/[eventId]/page.tsx
@@ -118,7 +118,16 @@ export default function MatchListPage() {
         // The button on Rankings page says "Back to Team Details", so we route there.
         const returnUrl = `/team/${teamNumber}`;
 
-        router.push(`/event-rankings/${eventId}?matchType=${matchType}&eventName=${encodeURIComponent(eventName)}&returnUrl=${encodeURIComponent(returnUrl)}`);
+        const params = new URLSearchParams({
+            matchType,
+            eventName,
+            returnUrl,
+            highlightTeam: teamNumber,
+        });
+        if (divisionId) params.append('divisionId', divisionId);
+        // divisionName isn't in the URL params for this page, but divisionId is enough
+        // for the rankings page to scope the results correctly.
+        router.push(`/event-rankings/${eventId}?${params.toString()}`);
     };
 
     if (!mounted) return null;


### PR DESCRIPTION
The "View Event Rankings" button in the match list page navigated to the rankings page without the divisionId, so multi-division events (e.g. US Open with Red/Blue/Green/Orange divisions) showed all teams instead of scoping to the team's actual division.

divisionId is already read from URL params on this page — it just wasn't included in the outbound navigation URL.