### PR TITLE
Propagate divisionName through team to match list to rankings nav

### DIFF
--- a/frontend-nextjs/src/app/team/[teamNumber]/event/[eventId]/page.tsx
+++ b/frontend-nextjs/src/app/team/[teamNumber]/event/[eventId]/page.tsx
@@ -26,6 +26,7 @@ export default function MatchListPage() {
 
     // Get query params passed from the previous page
     const divisionId = searchParams.get('divisionId') || '';
+    const divisionName = searchParams.get('divisionName') || '';
     const matchType = searchParams.get('matchType') || 'VRC';
     const eventName = searchParams.get('eventName') || 'Event Matches';
     const eventStart = searchParams.get('start') || '';
@@ -131,8 +132,7 @@ export default function MatchListPage() {
             highlightTeam: teamNumber,
         });
         if (divisionId) params.append('divisionId', divisionId);
-        // divisionName isn't in the URL params for this page, but divisionId is enough
-        // for the rankings page to scope the results correctly.
+        if (divisionName) params.append('divisionName', divisionName);
         router.push(`/event-rankings/${eventId}?${params.toString()}`);
     };
 

--- a/frontend-nextjs/src/components/team/EventsSection.tsx
+++ b/frontend-nextjs/src/components/team/EventsSection.tsx
@@ -98,6 +98,7 @@ export function EventsSection({
         start: event.start,
         end: event.end
       });
+      if (divisionName) params.append('divisionName', divisionName);
       router.push(`/team/${teamNumber}/event/${event.id}?${params.toString()}`);
     } else {
       // Future event → rankings page


### PR DESCRIPTION
## Summary
- The new division stat card on /event-rankings (PR #66) only shows when divisionName is in the URL or API response.
- The navigation chain team detail → match list → event rankings was dropping divisionName along the way, leaving the rankings page in fallback mode even when filtered.
- Add divisionName to both URLSearchParams hops; backend unchanged.

## Test plan
- [ ] Visit team detail page, click a single-division event, click "View Event Rankings" — confirm the first stat card now shows "Division: <name>" instead of "Total Teams".
- [ ] Same path for a multi-division event (e.g. Worlds) — confirm the resolved division name appears.
- [ ] Direct deep links with divisionId only (no divisionName) still fall back gracefully to "Total Teams" — no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)