### PR TITLE
Fix division filter returning all event teams pre-event

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1508,6 +1508,39 @@ app.get('/api/events/:eventId/rankings', async (req, res) => {
         divPage++;
       }
       console.log(`Found ${divisionTeamNumbers.size} teams in division ${parsedDivisionId} for event ${eventId}`);
+
+      // Fallback: if the rankings endpoint returned no teams (common before an event
+      // starts — rankings only exist once matches have been played), derive division
+      // membership from the match schedule instead. Match schedules are typically
+      // published before the event runs.
+      if (divisionTeamNumbers.size === 0) {
+        let matchPage = 1;
+        let matchHasMore = true;
+        while (matchHasMore) {
+          const matchRes = await fetch(
+            `https://www.robotevents.com/api/v2/events/${eventId}/divisions/${parsedDivisionId}/matches?page=${matchPage}&per_page=250`,
+            {
+              headers: {
+                'Authorization': `Bearer ${apiToken}`,
+                'Accept': 'application/json'
+              }
+            }
+          );
+          if (!matchRes.ok) break;
+          const matchData = await matchRes.json();
+          (matchData.data || []).forEach(m => {
+            (m.alliances || []).forEach(a => {
+              (a.teams || []).forEach(t => {
+                if (t.team?.name) divisionTeamNumbers.add(t.team.name.toUpperCase());
+              });
+            });
+          });
+          const matchMeta = matchData.meta || {};
+          matchHasMore = matchMeta.current_page < matchMeta.last_page;
+          matchPage++;
+        }
+        console.log(`Matches-endpoint fallback found ${divisionTeamNumbers.size} teams in division ${parsedDivisionId}`);
+      }
     }
 
     // Step 1b: Fetch ALL teams registered for this event (for grade info and team metadata).
@@ -1557,8 +1590,12 @@ app.get('/api/events/:eventId/rankings', async (req, res) => {
 
     console.log(`Fetched ${allTeams.length} teams for event ${eventId} across ${currentPage - 1} page(s)`);
 
-    // If filtering by division, narrow allTeams to only those in the division
-    if (divisionTeamNumbers && divisionTeamNumbers.size > 0) {
+    // If filtering by division, narrow allTeams to only those in the division.
+    // Note: we gate on `divisionTeamNumbers` (not `.size > 0`). If a division was
+    // requested but membership couldn't be resolved from either rankings or the
+    // match schedule, return zero teams rather than silently unfiltering to the
+    // whole event.
+    if (divisionTeamNumbers) {
       allTeams = allTeams.filter(t => divisionTeamNumbers.has(t.number.toUpperCase()));
       console.log(`Filtered to ${allTeams.length} teams in division ${parsedDivisionId}`);
     }


### PR DESCRIPTION
## Summary
- Division-scoped event rankings silently returned the entire event (585 teams at Worlds 2026) instead of the ~80-150 teams in the requested division when the event hadn't started yet.
- Root cause: the handler resolves division membership via `/events/{id}/divisions/{divId}/rankings`, which is empty until matches are played. The filter gate `divisionTeamNumbers.size > 0` then unfiltered the list entirely.
- Fix: fall back to `/events/{id}/divisions/{divId}/matches` (populated as soon as the schedule is posted) when rankings is empty, and tighten the gate so that an unresolvable division returns zero teams instead of the whole event.

## Test plan
- [ ] Post-deploy, hit `/api/events/64026/rankings?matchType=VRC&divisionId=1` and confirm `teamsInEvent` is ~80-150, not 585.
- [ ] Hit `/api/events/60404/rankings?matchType=VRC&divisionId=3` and confirm the past-event path still returns ~34 teams (rankings endpoint still preferred, fallback not triggered).
- [ ] Load `vexscouting.ca/event-rankings/64026?matchType=VRC&divisionId=1&divisionName=Science` and verify only Science-division teams appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)