### PR TITLE
Stop guessing divisions[0] for upcoming multi-division events

### DIFF
--- a/frontend-nextjs/src/components/team/EventsSection.tsx
+++ b/frontend-nextjs/src/components/team/EventsSection.tsx
@@ -59,8 +59,14 @@ export function EventsSection({
   const handleEventClick = async (event: TeamEvent) => {
     if (resolvingEventId === event.id) return; // prevent double-click during lookup
 
-    let divisionId: string = event.divisions[0]?.id?.toString() || '';
-    let divisionName: string = event.divisions[0]?.name || '';
+    // Single-division events: safe to use the sole division directly.
+    // Multi-division events: leave empty and let the resolver decide — we must
+    // NOT guess `divisions[0]`, because that masquerades as a real resolution
+    // (e.g. labels an upcoming Worlds entry as "Science" before the match
+    // schedule is posted, then the rankings page filters to a division the
+    // team isn't actually in).
+    let divisionId: string = event.divisions.length === 1 ? (event.divisions[0]?.id?.toString() || '') : '';
+    let divisionName: string = event.divisions.length === 1 ? (event.divisions[0]?.name || '') : '';
 
     // Multi-division events (World Championship) need an API call to find which
     // specific division this team competes in. Single-division events skip this.


### PR DESCRIPTION
## Summary
- The Team Details → event card nav defaulted \`divisionId\`/\`divisionName\` to \`event.divisions[0]\` before calling the division resolver. When the resolver returned \`null\` (upcoming Worlds events, where neither rankings nor the match schedule are published yet), that guess stuck — every team's card navigated to the rankings page claiming "Science" division.
- Combined with PR #68 (backend now strictly filters to the requested division), this surfaced as an empty rankings page for Worlds 2026. Before #68, the bug hid behind a silent unfilter.
- Fix: only default to \`divisions[0]\` when there's exactly one division. For multi-division events, leave empty when the resolver can't resolve, so the rankings page shows the full event with no misleading division label.

## Test plan
- [ ] Click an upcoming Worlds event card → confirm dialog says the event name with no "— Science" suffix; rankings page shows all event teams, no division card.
- [ ] Click a past multi-division event where the resolver succeeds (e.g. event 60404) → rankings page still shows the resolved division only.
- [ ] Click a single-division event (regional) → behavior unchanged, divisionId passed through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)