### PR TITLE
Fix duplicate tier chip / strength badge in match-up team rows

### DIFF
--- a/frontend-nextjs/src/components/team/VrcMatchCard.tsx
+++ b/frontend-nextjs/src/components/team/VrcMatchCard.tsx
@@ -150,32 +150,6 @@ function TeamRow({
                         )}
                     </>
                 )}
-                {showAnalysis && performanceData && (
-                    <>
-                        <TierChip tier={performanceData.tier} />
-                        <TooltipProvider>
-                            <Tooltip
-                                content={
-                                    <div className="text-xs space-y-0.5">
-                                        <div>WR: {performanceData.winRate}</div>
-                                        <div>CCWM: {performanceData.ccwm ?? '—'}</div>
-                                        <div>Skills: {performanceData.skills}</div>
-                                        <div>Events: {performanceData.n ?? '—'}</div>
-                                    </div>
-                                }
-                            >
-                                <Badge variant="secondary" className="text-xs font-normal bg-gray-100 text-gray-700 cursor-help">
-                                    S:{performanceData.strength}
-                                </Badge>
-                            </Tooltip>
-                        </TooltipProvider>
-                        {(performanceData.n ?? 0) > 0 && (performanceData.n ?? 0) <= 2 && (
-                            <span className="text-xs text-amber-600" title={`Based on only ${performanceData.n} event(s) — score may be unreliable.`}>
-                                ?
-                            </span>
-                        )}
-                    </>
-                )}
                 {team.team.rank && (
                     <Badge variant="outline" className="text-xs font-normal text-gray-500 bg-white">
                         Rank #{team.team.rank}


### PR DESCRIPTION
## Problem

In the match-up analysis, every team row rendered its tier chip and `S:` strength badge **twice** — e.g. `Mid-High S:21 Mid-High S:21`, `Elite S:44 Elite S:44`. The team name and rank appeared once, which is the tell that this was a render-level duplication, not duplicated data.

## Cause

`TeamRow` in `VrcMatchCard.tsx` contained two byte-identical copies of the `{showAnalysis && performanceData && (…)}` block (the `<TierChip>` + strength `<Badge>` + thin-data indicator).

## Fix

Removed the duplicated block so each row renders the chip and badge exactly once. Pure deletion (26 lines), no behavior change beyond removing the visual duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)